### PR TITLE
fixed google analytics

### DIFF
--- a/src/components/common/Analytics.astro
+++ b/src/components/common/Analytics.astro
@@ -1,13 +1,21 @@
 ---
-import { GoogleAnalytics } from '@astrolib/analytics';
 import { ANALYTICS } from 'astrowind:config';
+
+const gaId = ANALYTICS?.vendors?.googleAnalytics?.id;
+
+const gaScript = gaId
+  ? `window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '${gaId}');`
+  : '';
 ---
 
 {
-  ANALYTICS?.vendors?.googleAnalytics?.id ? (
-    <GoogleAnalytics
-      id={String(ANALYTICS.vendors.googleAnalytics.id)}
-      partytown={ANALYTICS?.vendors?.googleAnalytics?.partytown}
-    />
-  ) : null
+  gaId && (
+    <>
+      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} />
+      <script is:inline set:html={gaScript} />
+    </>
+  )
 }


### PR DESCRIPTION
Replaced the package-based implementation with a direct Google Analytics 4 script injection:
Loads the gtag.js script from Google Tag Manager
Initializes the dataLayer
Configures GA with your measurement ID: G-297BFKJMMY

I then made it compliant with Prettier.