### PR TITLE
Add links to original sources of blog posts at the top of their respective pages

### DIFF
--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -20,6 +20,17 @@ const { post, url } = Astro.props;
 const isRemoteImage =
   typeof post.image === 'string' &&
   (post.image.startsWith('http') || post.image.startsWith('/assets/') || post.image.startsWith('/blog_images/'));
+
+// Determine the canonical source name
+const getCanonicalSourceName = () => {
+  if (post.metadata?.canonicalSource) {
+    return post.metadata.canonicalSource;
+  }
+  if (post.metadata?.canonical?.startsWith('https://lfaller.github.io')) {
+    return 'Original Source: Carriagetown Data Solutions';
+  }
+  return 'Original Source';
+};
 ---
 
 <section class="py-8 sm:py-16 lg:py-20 mx-auto">
@@ -87,6 +98,18 @@ const isRemoteImage =
                       : `${post.readingTime} min read`}
                   </span>
                 </>
+              </>
+            )
+          }
+          {
+            post.metadata?.canonical && (
+              <>
+                {' '}
+                ·{' '}
+                <a href={post.metadata.canonical} target="_blank" rel="noopener noreferrer" class="hover:underline">
+                  <Icon name="tabler:external-link" class="w-4 h-4 inline-block -mt-0.5 dark:text-gray-400" />
+                  {getCanonicalSourceName()}
+                </a>
               </>
             )
           }

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -29,6 +29,9 @@ const getCanonicalSourceName = () => {
   if (post.metadata?.canonical?.startsWith('https://lfaller.github.io')) {
     return 'Original Source: Carriagetown Data Solutions';
   }
+  if (post.metadata?.canonical?.startsWith('https://smartlink.ausha.co/a-coffee-with-compbio')) {
+    return 'Coffee With CompBio';
+  }
   return 'Original Source';
 };
 ---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,6 +8,7 @@ const metadataDefinition = () =>
       ignoreTitleTemplate: z.boolean().optional(),
 
       canonical: z.string().url().optional(),
+      canonicalSource: z.string().optional(),
 
       robots: z
         .object({

--- a/src/content/post/20251028_video_workLifeDecoded.md
+++ b/src/content/post/20251028_video_workLifeDecoded.md
@@ -24,6 +24,7 @@ metadata:
   title: 'Work Life Decoded: Welcome to the Series!'
   description: 'A new video series that cuts through the myths with real talk on science and careers.'
   canonical: https://www.patreon.com/posts/welcome-to-work-142167916
+  canonicalSource: 'Work Life Decoded'
 ---
 
 Women in Bioinformatics chairs Lorena and Lina introduce their new video series tackling the career challenges that keep bioinformatics professionals up at night. With over 40 years of combined experience at Harvard, eGenesis, Ginkgo Bioworks, and other leading organizations, they're sharing the honest conversations about workplace dynamics, negotiation, and career navigation that they wish they'd had access to earlier in their careers.

--- a/src/content/post/20251104_video_workLifeDecoded.md
+++ b/src/content/post/20251104_video_workLifeDecoded.md
@@ -25,6 +25,7 @@ metadata:
   title: "Work Life Decoded: Your Weekly Win Log – The Career Tool You Didn't Know You Needed"
   description: 'Why you should keep a weekly log of your wins (and how it can transform your career)'
   canonical: https://www.patreon.com/posts/your-weekly-win-142523683
+  canonicalSource: 'Work Life Decoded'
 ---
 
 In their latest video, Women in Bioinformatics chairs Lorena and Lina tackle a deceptively simple practice that can transform your career: keeping a weekly log of your wins and quantifying your achievements.

--- a/src/content/post/20251110_video_workLifeDecoded.md
+++ b/src/content/post/20251110_video_workLifeDecoded.md
@@ -24,6 +24,7 @@ metadata:
   title: 'Work Life Decoded: How to Handle Workplace Negativity (Without Becoming the Office Therapist)'
   description: 'Practical strategies for handling workplace negativity without getting dragged into the drama or becoming everyone’s emotional dumping ground'
   canonical: https://www.patreon.com/posts/143081096
+  canonicalSource: 'Work Life Decoded'
 ---
 
 “That person is SO incompetent.” “This project is a disaster.” “Management has no idea what they’re doing.”

--- a/src/content/post/20251118_video_workLifeDecoded.md
+++ b/src/content/post/20251118_video_workLifeDecoded.md
@@ -25,6 +25,7 @@ metadata:
   title: "Work Life Decoded: Understanding Your Manager's World"
   description: 'How to Building a Strategic Partnership with Your Boss'
   canonical: https://www.patreon.com/posts/new-video-your-143734360
+  canonicalSource: 'Work Life Decoded'
 ---
 
 **Your manager isn’t your boss. They’re your business partner.**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -92,6 +92,7 @@ export interface MetaData {
   ignoreTitleTemplate?: boolean;
 
   canonical?: string;
+  canonicalSource?: string;
 
   robots?: MetaDataRobots;
 


### PR DESCRIPTION
link original source to canonical URL, added canonicalSource to the frontmatter to set name to link at the top of the blog post. By default, the canonicalSource is "Original Source" but any url with Lina's website will say "Original Source: Carriagetown Data Solutions".