### PR TITLE
add button to fill out promotion form

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -99,6 +99,18 @@ const metadata = {
           href: 'https://luma.com/bwib',
         },
       },
+      {
+        title: 'Promote Your Event',
+        description: 'Have an event relevant to our community? Fill out our form!',
+        icon: 'tabler:speakerphone',
+        callToAction: {
+          target: '_blank',
+          href: 'https://forms.gle/K2ofV58M1JPoYRX69',
+        },
+        classes: {
+          panel: 'sm:col-span-2',
+        },
+      },
     ]}
   />
 </Layout>


### PR DESCRIPTION
People from other organizations can fill out this form so we can add their events to our website and newsletter.