### PR TITLE
fix date time white space between time and timezone

### DIFF
--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -56,7 +56,7 @@ const getTimeZoneAbbr = (d: Date) =>
     </time>
   ) : isSameDayWithEnd ? (
     <time datetime={startDate.toISOString()}>
-      {formatSingle(startDate)} – {formatTimeOnly(endDateObj!)} {getTimeZoneAbbr(endDateObj!)}
+      {formatSingle(startDate)} – {formatTimeOnly(endDateObj!)}&nbsp;{getTimeZoneAbbr(endDateObj!)}
     </time>
   ) : (
     <time datetime={startDate.toISOString()}>{formatSingle(startDate)}</time>


### PR DESCRIPTION
The issue is JSX collapses whitespace between expressions. Use &nbsp; as a string expression instead, which prettier won't touch.