### PR TITLE
Fix broken Resources and Templates link

### DIFF
--- a/src/content/post/20251205_guide_startChapter.md
+++ b/src/content/post/20251205_guide_startChapter.md
@@ -30,7 +30,7 @@ metadata:
 - [Community Building: The Soft Skills](community-building:-the-soft-skills)
 - [Common Pitfalls and How to Avoid Them](common-pitfalls-and-how-to-avoid-them)
 - [Timeline: First Year Milestones](timeline:-first-year-milestones)
-- [Resources and Templates](resources-and-templates)
+- [Resources and Templates](#resources-and-templates)
 - [Final Words of Encouragement](final-words-of-encouragement)
 
 ## Getting Started: The Foundation


### PR DESCRIPTION
Fixes #348.

The "Resources and Templates" link in `starting-a-women-in-bioinformatics-chapter` points to a non-existent page. The content is in the same post under the "Resources and Templates" section, so this switches the link to the in-page anchor (`#resources-and-templates`).